### PR TITLE
Integracao com Google Calendar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.8</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,16 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.apis</groupId>
+			<artifactId>google-api-services-calendar</artifactId>
+			<version>v3-rev20230707-2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.auth</groupId>
+			<artifactId>google-auth-library-oauth2-http</artifactId>
+			<version>1.19.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/todo/application/controller/CalendarController.java
+++ b/src/main/java/com/example/todo/application/controller/CalendarController.java
@@ -1,0 +1,57 @@
+package com.example.todo.application.controller;
+
+import java.net.URI;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.todo.domain.repository.UserRepositoryPort;
+import com.example.todo.infrastructure.calendar.oauth.GoogleOAuthProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/calendar")
+@RequiredArgsConstructor
+public class CalendarController {
+    private final GoogleOAuthProvider oauthProvider;
+    private final UserRepositoryPort userRepository;
+
+    @Operation(
+        summary = "Redirecionamento do usuário para iniciar o fluxo authorization code OAuth2 da autenticação do Google",
+        description = "O usuário deve deve abrir este endpoint em seu browser para iniciar o fluxo de autenticação."
+    )
+    @ApiResponse(responseCode = "302")
+    @GetMapping("/oauth2/googlecalendar/redirect")
+    public ResponseEntity<Void> redirectGoogleCalendar() {
+        URI location = oauthProvider.getAuthorizationCodeUrl();
+        
+        return ResponseEntity
+                .status(HttpStatus.FOUND) // 302            
+                .location(location)
+                .build();
+    }
+
+    @Operation(
+        summary = "Callback para o fluxo authorization code OAuth2 da autenticação do Google",
+        description = "A página de autenticação/consentimento do Google redirecionará o usuário para este endpoint." 
+    )
+    @ApiResponse(responseCode = "204")
+    @GetMapping("/oauth2/googlecalendar/callback")
+    public ResponseEntity<Void> callbackGoogleCalendar(
+        @RequestParam(name = "code") String code
+    ) {
+        String refreshToken = oauthProvider.getRefreshTokenFromCode(code);
+        UUID currentUserId = UUID.fromString("cfd1cacd-fe74-4113-8c66-b84677237ea3"); // TODO, fix when auth works
+        userRepository.updateExternalCalendarToken(currentUserId, refreshToken);
+        
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/todo/domain/model/CalendarEvent.java
+++ b/src/main/java/com/example/todo/domain/model/CalendarEvent.java
@@ -1,0 +1,19 @@
+package com.example.todo.domain.model;
+
+import java.time.OffsetDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder(toBuilder = true)
+@Getter
+@Setter
+public class CalendarEvent {
+    private String title;
+    private String description;
+    private OffsetDateTime startTime;
+    private OffsetDateTime endTime;
+    private String externalEventId;
+    private String externalToken;
+}

--- a/src/main/java/com/example/todo/domain/model/Task.java
+++ b/src/main/java/com/example/todo/domain/model/Task.java
@@ -1,10 +1,11 @@
 package com.example.todo.domain.model;
 
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.UUID;
 
 @Builder(toBuilder = true)
 @Getter
@@ -16,4 +17,21 @@ public class Task {
     private String title;
     private String description;
     private String status;
+    private OffsetDateTime expectedCompletionDate;
+    private String externalCalendarEventId;
+
+    public CalendarEvent toCompletionDateCalendarEvent() {
+        return CalendarEvent.builder()
+            .externalEventId(externalCalendarEventId)
+            .title("Deadline: " + title)
+            .description(description)
+            .startTime(expectedCompletionDate)
+            .endTime(expectedCompletionDate.plusHours(1))
+            .externalToken(owner.getExternalCalendarServiceToken())
+            .build();
+    }
+
+    public boolean isAssigned() {
+        return assignedToUser != null;
+    }
 }

--- a/src/main/java/com/example/todo/domain/model/User.java
+++ b/src/main/java/com/example/todo/domain/model/User.java
@@ -1,10 +1,10 @@
 package com.example.todo.domain.model;
 
+import java.util.UUID;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.UUID;
 
 @Builder(toBuilder = true)
 @Getter
@@ -13,4 +13,9 @@ public class User {
     private UUID id;
     private String name;
     private String email;
+    private String externalCalendarServiceToken;
+
+    public boolean usesExternalCalendarService() {
+        return externalCalendarServiceToken != null;
+    }
 }

--- a/src/main/java/com/example/todo/domain/repository/CalendarSink.java
+++ b/src/main/java/com/example/todo/domain/repository/CalendarSink.java
@@ -1,0 +1,15 @@
+package com.example.todo.domain.repository;
+
+import com.example.todo.domain.model.CalendarEvent;
+
+import jakarta.validation.constraints.NotNull;
+
+public interface CalendarSink {
+    @NotNull
+    CalendarEvent insertEvent(@NotNull CalendarEvent event);
+    
+    @NotNull
+    void editEvent(@NotNull CalendarEvent event);
+    
+    void deleteEvent(@NotNull CalendarEvent event);
+} 

--- a/src/main/java/com/example/todo/domain/repository/UserRepositoryPort.java
+++ b/src/main/java/com/example/todo/domain/repository/UserRepositoryPort.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 
 public interface UserRepositoryPort {
     Optional<User> findById(UUID userId);
+    void updateExternalCalendarToken(UUID userId, String token);
 }

--- a/src/main/java/com/example/todo/domain/service/CalendarService.java
+++ b/src/main/java/com/example/todo/domain/service/CalendarService.java
@@ -1,0 +1,61 @@
+package com.example.todo.domain.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.todo.domain.model.CalendarEvent;
+import com.example.todo.domain.model.Task;
+import com.example.todo.domain.repository.CalendarSink;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+    private final CalendarSink calendarSink;
+    
+    public CalendarEvent insertCompletionDateEvent(Task task) {
+        if (!shouldUseCalendarService(task)) {
+            return null;
+        }
+        
+        CalendarEvent calendarEvent = task.toCompletionDateCalendarEvent();
+
+        return calendarSink.insertEvent(calendarEvent);
+    }
+    
+    public void editCompletionDateEvent(Task task) {
+        if (!shouldUseCalendarService(task)) {
+            return;
+        }
+
+        CalendarEvent calendarEvent = task.toCompletionDateCalendarEvent();
+
+        if (calendarEvent.getExternalEventId() == null)
+        {
+            calendarSink.insertEvent(calendarEvent);
+            return;
+        }
+
+        calendarSink.editEvent(calendarEvent);
+    }
+    
+    public void deleteCompletionDateEvent(Task task) {
+        if (!shouldUseCalendarService(task)) {
+            return;
+        }
+
+        CalendarEvent calendarEvent = task.toCompletionDateCalendarEvent();
+
+        if (calendarEvent.getExternalEventId() == null)
+        {
+            return;
+        }
+
+        calendarSink.deleteEvent(calendarEvent);
+    }
+
+    private boolean shouldUseCalendarService(Task task) {
+        return task.isAssigned() && 
+            task.getAssignedToUser().usesExternalCalendarService();
+    }
+} 

--- a/src/main/java/com/example/todo/infrastructure/calendar/GoogleCalendarService.java
+++ b/src/main/java/com/example/todo/infrastructure/calendar/GoogleCalendarService.java
@@ -1,0 +1,69 @@
+package com.example.todo.infrastructure.calendar;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import org.springframework.stereotype.Service;
+
+import com.example.todo.infrastructure.calendar.oauth.GoogleOAuthProvider;
+import com.google.api.client.auth.oauth2.BearerToken;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.Event;
+import com.google.api.services.calendar.model.EventDateTime;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleCalendarService {
+    
+    private static final String CALENDAR_ID = "primary";
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
+    private final GoogleOAuthProvider googleOAuthProvider;
+    
+    public Event insertEvent(Event event, String refreshToken) throws IOException, GeneralSecurityException {
+        Calendar service = getCalendarService(refreshToken);
+        return service.events().insert(CALENDAR_ID, event).execute();
+    }
+    
+    public Event updateEvent(Event event, String eventId, String refreshToken) throws IOException, GeneralSecurityException {
+        Calendar service = getCalendarService(refreshToken);
+        return service.events().update(CALENDAR_ID, eventId, event).execute();
+    }
+    
+    public void deleteEvent(String eventId, String refreshToken) throws IOException, GeneralSecurityException {
+        Calendar service = getCalendarService(refreshToken);
+        service.events().delete(CALENDAR_ID, eventId).execute();
+    }
+    
+    public Event createGoogleEvent(String title, String description, DateTime startTime, DateTime endTime) {
+        Event calendarEvent = new Event()
+            .setSummary(title)
+            .setDescription(description);
+        
+        EventDateTime start = new EventDateTime().setDateTime(startTime);
+        calendarEvent.setStart(start);
+        
+        EventDateTime end = new EventDateTime().setDateTime(endTime);
+        calendarEvent.setEnd(end);
+        
+        return calendarEvent;
+    }
+    
+    private Calendar getCalendarService(String refreshToken) throws IOException, GeneralSecurityException {
+        NetHttpTransport HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
+        
+        String accessToken = googleOAuthProvider.getAccessTokenFromRefreshToken(refreshToken);
+        Credential credential = new Credential(BearerToken.authorizationHeaderAccessMethod())
+            .setAccessToken(accessToken);
+        
+        return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
+            .build();
+    }
+} 

--- a/src/main/java/com/example/todo/infrastructure/calendar/GoogleCalendarSink.java
+++ b/src/main/java/com/example/todo/infrastructure/calendar/GoogleCalendarSink.java
@@ -1,0 +1,72 @@
+package com.example.todo.infrastructure.calendar;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import org.springframework.stereotype.Component;
+
+import com.example.todo.domain.model.CalendarEvent;
+import com.example.todo.domain.repository.CalendarSink;
+import com.google.api.client.util.DateTime;
+import com.google.api.services.calendar.model.Event;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleCalendarSink implements CalendarSink {
+    private final GoogleCalendarService googleCalendarService;
+    
+    @Override
+    public CalendarEvent insertEvent(CalendarEvent event) {
+        try {
+            Event googleEvent = createGoogleEvent(event);
+            Event createdEvent = googleCalendarService.insertEvent(googleEvent, event.getExternalToken());
+            
+            event.setExternalEventId(createdEvent.getId());
+            return event;
+            
+        } catch (IOException | GeneralSecurityException e) {
+            throw new RuntimeException("Failed to create calendar event", e);
+        }
+    }
+    
+    @Override
+    public void editEvent(CalendarEvent event) {
+        if (event.getExternalEventId() == null) {
+            throw new IllegalArgumentException("Event must have an external ID to be edited");
+        }
+
+        try {
+            Event googleEvent = createGoogleEvent(event);
+            googleCalendarService.updateEvent(googleEvent, event.getExternalEventId(), event.getExternalToken());
+        } catch (IOException | GeneralSecurityException e) {
+            throw new RuntimeException("Failed to update calendar event", e);
+        }
+    }
+    
+    @Override
+    public void deleteEvent(CalendarEvent calendarEvent) {
+        if (calendarEvent.getExternalEventId() == null) {
+            throw new IllegalArgumentException("Event must have an external ID to be deleted");
+        }
+
+        try {
+            googleCalendarService.deleteEvent(calendarEvent.getExternalEventId(), calendarEvent.getExternalToken());
+        } catch (IOException | GeneralSecurityException e) {
+            throw new RuntimeException("Failed to delete calendar event", e);
+        }
+    }
+    
+    private Event createGoogleEvent(CalendarEvent event) {
+        DateTime startDateTime = new DateTime(event.getStartTime().toInstant().toEpochMilli());
+        DateTime endDateTime = new DateTime(event.getEndTime().toInstant().toEpochMilli());
+        
+        return googleCalendarService.createGoogleEvent(
+            event.getTitle(),
+            event.getDescription(),
+            startDateTime,
+            endDateTime
+        );
+    }
+} 

--- a/src/main/java/com/example/todo/infrastructure/calendar/oauth/GoogleOAuthProvider.java
+++ b/src/main/java/com/example/todo/infrastructure/calendar/oauth/GoogleOAuthProvider.java
@@ -1,0 +1,86 @@
+package com.example.todo.infrastructure.calendar.oauth;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.example.todo.infrastructure.config.GoogleCalendarConfig;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeRequestUrl;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.UserCredentials;
+
+@Component
+public class GoogleOAuthProvider {
+    private final GoogleCalendarConfig config;
+    private final List<String> scopes = List.of("https://www.googleapis.com/auth/calendar");
+
+    public GoogleOAuthProvider(GoogleCalendarConfig config) {
+        this.config = config;
+    }
+
+    public URI getAuthorizationCodeUrl() {
+        GoogleAuthorizationCodeRequestUrl urlBuilder =
+            new GoogleAuthorizationCodeRequestUrl(
+                config.getClientId(),
+                config.getRedirectUri(),
+                this.scopes
+            )
+            .setAccessType("offline")
+            .set("prompt", "select_account consent");
+
+        return URI.create(urlBuilder.build());
+    }
+
+
+    public String getRefreshTokenFromCode(String code) {
+        JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
+        HttpTransport HTTP_TRANSPORT;
+
+        try {
+            HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
+        } catch (GeneralSecurityException | IOException ex) {
+            return null; // TODO
+        }
+
+        GoogleTokenResponse tokenResponse;
+        try {
+            tokenResponse = new GoogleAuthorizationCodeTokenRequest(
+                    HTTP_TRANSPORT,
+                    JSON_FACTORY,
+                    config.getClientId(),
+                    config.getClientSecret(),
+                    code,
+                    config.getRedirectUri()
+            ).execute();
+        } catch (IOException ex) {
+            // TODO
+            return null;
+        }
+
+        return tokenResponse.getRefreshToken();
+    }
+
+    public String getAccessTokenFromRefreshToken(String refreshToken) {
+        try {
+            GoogleCredentials credentials = UserCredentials.newBuilder()
+                .setClientId(config.getClientId())
+                .setClientSecret(config.getClientSecret())
+                .setRefreshToken(refreshToken)
+                .build();
+            
+            credentials.refreshIfExpired();
+            return credentials.getAccessToken().getTokenValue();
+        } catch (IOException ex) {
+            return null; // TODO
+        }
+    }
+}

--- a/src/main/java/com/example/todo/infrastructure/config/GoogleCalendarConfig.java
+++ b/src/main/java/com/example/todo/infrastructure/config/GoogleCalendarConfig.java
@@ -1,0 +1,14 @@
+package com.example.todo.infrastructure.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "google.calendar")
+public class GoogleCalendarConfig {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+} 

--- a/src/main/java/com/example/todo/infrastructure/model/TaskDto.java
+++ b/src/main/java/com/example/todo/infrastructure/model/TaskDto.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Entity
@@ -37,4 +38,6 @@ public class TaskDto {
     private UserDto assignedUser;
     @NotNull
     private Date createAt;
+    private OffsetDateTime expectedCompletionDate;
+    private String externalCalendarEventId;
 }

--- a/src/main/java/com/example/todo/infrastructure/model/TaskDto.java
+++ b/src/main/java/com/example/todo/infrastructure/model/TaskDto.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -11,6 +12,7 @@ import java.util.Date;
 import java.util.UUID;
 
 @Entity
+@Table(name = "tasks")
 @Setter
 @Getter
 @Builder(toBuilder = true)

--- a/src/main/java/com/example/todo/infrastructure/model/TaskMapper.java
+++ b/src/main/java/com/example/todo/infrastructure/model/TaskMapper.java
@@ -11,10 +11,12 @@ public class TaskMapper {
             .status(taskDto.getStatus())
             .assignedToUser(UserMapper.toDomain(taskDto.getAssignedUser()))
             .owner(UserMapper.toDomain(taskDto.getOwnerUser()))
+            .expectedCompletionDate(taskDto.getExpectedCompletionDate())
+            .externalCalendarEventId(taskDto.getExternalCalendarEventId())
             .build();
     }
 
-    public TaskDto toDto(Task task) {
+    public static TaskDto toDto(Task task) {
         return TaskDto.builder()
             .id(task.getId())
             .ownerUser(UserMapper.toDto(task.getOwner()))
@@ -22,6 +24,8 @@ public class TaskMapper {
             .title(task.getTitle())
             .description(task.getDescription())
             .status(task.getStatus())
+            .expectedCompletionDate(task.getExpectedCompletionDate())
+            .externalCalendarEventId(task.getExternalCalendarEventId())
             .build();
     }
 }

--- a/src/main/java/com/example/todo/infrastructure/model/UserDto.java
+++ b/src/main/java/com/example/todo/infrastructure/model/UserDto.java
@@ -2,13 +2,14 @@ package com.example.todo.infrastructure.model;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
-import java.util.Date;
 import java.util.UUID;
 
 @Entity
+@Table(name = "users")
 @Setter
 @Getter
 @Builder(toBuilder = true)

--- a/src/main/java/com/example/todo/infrastructure/model/UserDto.java
+++ b/src/main/java/com/example/todo/infrastructure/model/UserDto.java
@@ -22,4 +22,5 @@ public class UserDto {
     private String name;
     @NotNull
     private String email;
+    private String externalCalendarServiceToken;
 }

--- a/src/main/java/com/example/todo/infrastructure/model/UserMapper.java
+++ b/src/main/java/com/example/todo/infrastructure/model/UserMapper.java
@@ -8,6 +8,7 @@ public class UserMapper {
             .id(userDto.getId())
             .name(userDto.getName())
             .email(userDto.getEmail())
+            .externalCalendarServiceToken((userDto.getExternalCalendarServiceToken()))
             .build();
     }
     public static UserDto toDto(User user) {
@@ -15,6 +16,7 @@ public class UserMapper {
             .id(user.getId())
             .name(user.getName())
             .email(user.getEmail())
+            .externalCalendarServiceToken((user.getExternalCalendarServiceToken()))
             .build();
     }
 }

--- a/src/main/java/com/example/todo/infrastructure/repository/TaskRepositoryAdapter.java
+++ b/src/main/java/com/example/todo/infrastructure/repository/TaskRepositoryAdapter.java
@@ -8,8 +8,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
 public class TaskRepositoryAdapter implements TaskRepositoryPort {
-    JpaTaskRepository taskRepository;
+    private final JpaTaskRepository taskRepository;
 
     @Override
     public Optional<Task> findById(UUID taskId) {
@@ -25,5 +31,4 @@ public class TaskRepositoryAdapter implements TaskRepositoryPort {
     public List<Task> findByAssignedUserId(UUID assignedUserId) {
         return taskRepository.findByAssignedUserId(assignedUserId).stream().map(TaskMapper::toDomain).toList();
     }
-
 }

--- a/src/main/java/com/example/todo/infrastructure/repository/UserRepositoryAdapter.java
+++ b/src/main/java/com/example/todo/infrastructure/repository/UserRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.example.todo.infrastructure.repository;
 
 import com.example.todo.domain.model.User;
 import com.example.todo.domain.repository.UserRepositoryPort;
+import com.example.todo.infrastructure.model.UserDto;
 import com.example.todo.infrastructure.model.UserMapper;
 
 import java.util.Optional;
@@ -19,5 +20,16 @@ public class UserRepositoryAdapter implements UserRepositoryPort {
     @Override
     public Optional<User> findById(UUID userId) {
         return userRepository.findById(userId).map(UserMapper::toDomain);
+    }
+
+    @Override
+    public void updateExternalCalendarToken(UUID userId, String token) {
+        Optional<UserDto> userOption = userRepository.findById(userId);
+
+        if (userOption.isPresent()) {
+            UserDto user = userOption.get();
+            user.setExternalCalendarServiceToken(token);
+            userRepository.save(user);
+        }
     }
 }

--- a/src/main/java/com/example/todo/infrastructure/repository/UserRepositoryAdapter.java
+++ b/src/main/java/com/example/todo/infrastructure/repository/UserRepositoryAdapter.java
@@ -7,8 +7,14 @@ import com.example.todo.infrastructure.model.UserMapper;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
 public class UserRepositoryAdapter implements UserRepositoryPort {
-    JpaUserRepository userRepository;
+    private final JpaUserRepository userRepository;
 
     @Override
     public Optional<User> findById(UUID userId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,8 @@ spring.datasource.username=${PG_USER:postgres}
 spring.datasource.password=${PG_PASSWORD:secret}
 
 spring.flyway.locations=classpath:db/migration
+
+# Google Calendar API Configuration
+google.calendar.client-id=${GOOGLE_CALENDAR_CLIENT_ID:dummy}
+google.calendar.client-secret=${GOOGLE_CALENDAR_CLIENT_SECRET:dummy}
+google.calendar.redirect-uri=http://localhost:8080/calendar/oauth2/googlecalendar/callback

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -2,7 +2,8 @@ CREATE TABLE users (
     id UUID PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
-    password_hash VARCHAR(255) NOT NULL
+    password_hash VARCHAR(255) NOT NULL,
+    external_calendar_service_token VARCHAR(255)
 );
 
 CREATE TYPE task_status AS ENUM ('todo', 'doing', 'done');
@@ -14,6 +15,8 @@ CREATE TABLE tasks (
     status task_status NOT NULL,
     owner_user_id UUID NOT NULL,
     assigned_user_id UUID NULL,
+    expected_completion_date TIMESTAMP,
+    external_calendar_event_id VARCHAR(255),
     CONSTRAINT fk_tasks_owner_user FOREIGN KEY (owner_user_id) REFERENCES users(id),
     CONSTRAINT fk_tasks_assigned_user FOREIGN KEY (assigned_user_id) REFERENCES users(id)
 );


### PR DESCRIPTION
Este PR adiciona a integração inicial com o google calendar. Tentei seguir a ideia de ports and adapters. Usei bibliotecas wrapper prontas do google para não ter que fazer as api calls na mão, pra poupar trabalho.

Ainda deixei alguns TODOs nos tratamentos de erros e também ainda não fiz nenhum tipo de criptografia do secret que salvamos, isso podemos fazer  depois.

Optei por salvar o secret do usuário na própria tabela de usuário e o id externo do evento na própria task porque achei que não valia a complexidade adicional de criar novas tabelas só pra isso. Adicionei um campo de data na tarefa para usar no evento do calendário, para uma data esperada de término.

Aproveitei e alterei o pacote do openapi para um que já tem o swagger ui junto, pra nos poupar trabalho.

